### PR TITLE
fix: 修复部分cv::Mat变量不显示及像素全为0的问题 (#8)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-watch-for-visual-studio-code",
-  "version": "0.0.2",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "image-watch-for-visual-studio-code",
-      "version": "0.0.2",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/resources/image-watch-panel.html
+++ b/resources/image-watch-panel.html
@@ -195,14 +195,17 @@
 
     function array_from_memory(memory, type) {
         const depth = type & 7;
+        if (depth === 0 || depth === 1) { return memory; }
+        const aligned = memory.buffer.byteLength === memory.byteLength && memory.byteOffset === 0
+            ? memory.buffer
+            : memory.buffer.slice(memory.byteOffset, memory.byteOffset + memory.byteLength);
         switch (depth) {
-            case 0: case 1: return memory;
-            case 2: return new Uint16Array(memory.buffer, memory.byteOffset, memory.byteLength / 2);
-            case 3: return new Int16Array(memory.buffer, memory.byteOffset, memory.byteLength / 2);
-            case 4: return new Int32Array(memory.buffer, memory.byteOffset, memory.byteLength / 4);
-            case 5: return new Float32Array(memory.buffer, memory.byteOffset, memory.byteLength / 4);
-            case 6: return new Float64Array(memory.buffer, memory.byteOffset, memory.byteLength / 8);
-            default: throw new Error('Unsupported depth: ' + depth);
+            case 2: return new Uint16Array(aligned);
+            case 3: return new Int16Array(aligned);
+            case 4: return new Int32Array(aligned);
+            case 5: return new Float32Array(aligned);
+            case 6: return new Float64Array(aligned);
+            default: return memory;
         }
     }
 
@@ -213,20 +216,26 @@
 
         if (!state.cvReady) { console.error('OpenCV.js 尚未加载'); return; }
 
+        const mem = memory instanceof Uint8Array
+            ? memory
+            : new Uint8Array(memory);
+
         let image = null;
 
         const depth = mat_type & 7;
         const channels = ((mat_type >> 3) & 63) + 1;
         const elemSize1 = [1, 1, 2, 2, 4, 4, 8][depth];
         const rowBytes = mat.cols * channels * elemSize1;
-        const srcStep = mat.step[0];
+        const srcStep = (mat.step && mat.step.length > 0 && mat.step[0] > 0)
+            ? mat.step[0]
+            : rowBytes;
 
         const use_addr = mat.data.addr;
         const addr = mat.datastart.addr;
-        const skip = use_addr - addr;
+        const skip = Math.max(0, use_addr - addr);
 
         if (skip === 0 && srcStep === rowBytes) {
-            const array = array_from_memory(memory, mat_type);
+            const array = array_from_memory(mem, mat_type);
             const expected = mat.rows * mat.cols * channels;
             const safe = array.length > expected ? array.subarray(0, expected) : array;
             image = new state.cvInstance.matFromArray(mat.rows, mat.cols, mat_type, safe);
@@ -235,10 +244,12 @@
             for (let row = 0; row < mat.rows; row++) {
                 const srcOff = skip + row * srcStep;
                 const dstOff = row * rowBytes;
-                image.data.set(
-                    memory.subarray(srcOff, srcOff + rowBytes),
-                    dstOff
-                );
+                if (srcOff + rowBytes <= mem.length) {
+                    image.data.set(
+                        mem.subarray(srcOff, srcOff + rowBytes),
+                        dstOff
+                    );
+                }
             }
         }
 
@@ -252,7 +263,7 @@
         image.delete();
 
         v.name = variable_name;
-        v.memory = memory.length;
+        v.memory = mem.length;
         v.id = variable_name + '_' + Date.now();
         v.dataAddrHex = mat.data.hex || '';
         v.step = mat.step || [];

--- a/resources/image-watch-panel.html
+++ b/resources/image-watch-panel.html
@@ -200,11 +200,11 @@
             ? memory.buffer
             : memory.buffer.slice(memory.byteOffset, memory.byteOffset + memory.byteLength);
         switch (depth) {
-            case 2: return new Uint16Array(aligned);
-            case 3: return new Int16Array(aligned);
-            case 4: return new Int32Array(aligned);
-            case 5: return new Float32Array(aligned);
-            case 6: return new Float64Array(aligned);
+            case 2: return new Uint16Array(aligned, 0, (aligned.byteLength >>> 1));
+            case 3: return new Int16Array(aligned, 0, (aligned.byteLength >>> 1));
+            case 4: return new Int32Array(aligned, 0, (aligned.byteLength >>> 2));
+            case 5: return new Float32Array(aligned, 0, (aligned.byteLength >>> 2));
+            case 6: return new Float64Array(aligned, 0, (aligned.byteLength >>> 3));
             default: return memory;
         }
     }

--- a/resources/image-watch-panel.html
+++ b/resources/image-watch-panel.html
@@ -230,9 +230,9 @@
             ? mat.step[0]
             : rowBytes;
 
-        const use_addr = mat.data.addr;
-        const addr = mat.datastart.addr;
-        const skip = Math.max(0, use_addr - addr);
+        const useAddrBig = BigInt(mat.data.hex || '0x0');
+        const startAddrBig = BigInt(mat.datastart.hex || '0x0');
+        const skip = Math.max(0, Number(useAddrBig - startAddrBig));
 
         if (skip === 0 && srcStep === rowBytes) {
             const array = array_from_memory(mem, mat_type);

--- a/src/debug-tracker.ts
+++ b/src/debug-tracker.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { ImageWatchWebviewViewProvider } from './image-watch-webview-view';
-import { findImagesInScope, MatVariable } from './mat-utils';
+import { findImagesInScope, MatVariable, matInfoToMessage } from './mat-utils';
 
 let watchedVariableNames: Set<string> = new Set();
 
@@ -90,7 +90,7 @@ function sendSetLocalVariables(mats: MatVariable[]) {
     const items = mats.map(m => ({
         variable_name: m.name,
         memory: m.memory,
-        mat: m.mat,
+        mat: matInfoToMessage(m.mat),
         from: 'local'
     }));
 
@@ -108,7 +108,7 @@ function sendUpdateVariable(m: MatVariable) {
             command: 'update_variable',
             variable_name: m.name,
             memory: m.memory,
-            mat: m.mat
+            mat: matInfoToMessage(m.mat)
         });
     });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { ImageWatchWebviewViewProvider } from './image-watch-webview-view';
-import { tryParseAsImage, readMatMemory } from './mat-utils';
+import { tryParseAsImage, readMatMemory, matInfoToMessage } from './mat-utils';
 import { createTrackerFactory, addWatchedVariable, clearWatchedVariables } from './debug-tracker';
 
 export function activate(context: vscode.ExtensionContext) {
@@ -79,7 +79,7 @@ export function activate(context: vscode.ExtensionContext) {
                     command: 'add_variable',
                     variable_name: varName,
                     memory: memory,
-                    mat: mat,
+                    mat: matInfoToMessage(mat),
                     from: 'watch'
                 });
             });

--- a/src/format-descriptor.ts
+++ b/src/format-descriptor.ts
@@ -184,7 +184,7 @@ function getMappingFields(mapping: FieldMapping): string[] {
 // ---------------------------------------------------------------------------
 
 interface Ptr {
-    addr: number;
+    addr: bigint;
     hex: string;
 }
 
@@ -192,14 +192,13 @@ function parseAnyPointer(variable: any): Ptr {
     const str = String(variable.value);
     const match = str.match(/0x[0-9a-fA-F]+/);
     if (!match) {
-        return { addr: 0, hex: '0x0000000000000000' };
+        return { addr: 0n, hex: '0x0000000000000000' };
     }
     const raw = match[0];
     const hex = raw.length < 18
         ? '0x' + raw.slice(2).padStart(16, '0')
         : raw.substring(0, 18);
-    const bigVal = BigInt(hex);
-    return { addr: Number(bigVal), hex };
+    return { addr: BigInt(hex), hex };
 }
 
 function parseIntValue(variable: any): number {
@@ -348,16 +347,16 @@ function resolveStep(mapping: StepMapping, variables: any[], cols: number, chann
     return fallback;
 }
 
-function evalSimpleExpr(expr: string, vars: Record<string, number>): number {
+function evalSimpleExpr(expr: string, vars: Record<string, bigint>): bigint {
     const tokens = expr.replace(/([+\-*()])/g, ' $1 ').split(/\s+/).filter(Boolean);
-    const output: (number | string)[] = [];
+    const output: bigint[] = [];
     const ops: string[] = [];
     const prec: Record<string, number> = { '+': 1, '-': 1, '*': 2 };
 
     function applyOp() {
         const op = ops.pop()!;
-        const b = output.pop() as number;
-        const a = output.pop() as number;
+        const b = output.pop()!;
+        const a = output.pop()!;
         if (op === '+') { output.push(a + b); }
         else if (op === '-') { output.push(a - b); }
         else if (op === '*') { output.push(a * b); }
@@ -373,18 +372,17 @@ function evalSimpleExpr(expr: string, vars: Record<string, number>): number {
             while (ops.length && prec[ops[ops.length - 1]] >= prec[tok]) { applyOp(); }
             ops.push(tok);
         } else {
-            const num = Number(tok);
-            if (!isNaN(num)) {
-                output.push(num);
+            if (/^-?\d+$/.test(tok)) {
+                output.push(BigInt(tok));
             } else if (vars[tok] !== undefined) {
                 output.push(vars[tok]);
             } else {
-                output.push(0);
+                output.push(0n);
             }
         }
     }
     while (ops.length) { applyOp(); }
-    return (output[0] as number) || 0;
+    return output[0] ?? 0n;
 }
 
 export function extractImageInfo(
@@ -411,8 +409,9 @@ export function extractImageInfo(
 
     const cvType = cvDepth + ((channels - 1) << 3);
 
-    const exprVars: Record<string, number> = {
-        rows, cols, channels, step: step[0], depth: cvDepth
+    const exprVars: Record<string, bigint> = {
+        rows: BigInt(rows), cols: BigInt(cols), channels: BigInt(channels),
+        step: BigInt(step[0]), depth: BigInt(cvDepth)
     };
 
     const datastartMember = findMember(variables, 'datastart');
@@ -428,15 +427,16 @@ export function extractImageInfo(
     } else {
         datastartPtr = dataPtr;
         const memSize = evalSimpleExpr(fmt.descriptor.memorySize, exprVars);
+        const endAddr = dataPtr.addr + memSize;
         dataendPtr = {
-            addr: dataPtr.addr + memSize,
-            hex: '0x' + (dataPtr.addr + memSize).toString(16).padStart(16, '0')
+            addr: endAddr,
+            hex: '0x' + endAddr.toString(16).padStart(16, '0')
         };
         exprVars['datastart'] = datastartPtr.addr;
         exprVars['dataend'] = dataendPtr.addr;
     }
 
-    const memorySize = evalSimpleExpr(fmt.descriptor.memorySize, exprVars);
+    const memorySize = Number(evalSimpleExpr(fmt.descriptor.memorySize, exprVars));
     if (memorySize <= 0) { return null; }
 
     const flagsMember = findMember(variables, 'flags');

--- a/src/format-descriptor.ts
+++ b/src/format-descriptor.ts
@@ -143,10 +143,40 @@ export function matchesType(fmt: CompiledFormat, typeStr: string): boolean {
 }
 
 export function matchesMembers(fmt: CompiledFormat, variables: any[]): boolean {
-    if (variables.length !== fmt.descriptor.members.length) {
-        return false;
+    const names = new Set(variables.map(v => v.name));
+    const required = getMappingFields(fmt.descriptor.mapping);
+    return required.every(name => names.has(name));
+}
+
+function getMappingFields(mapping: FieldMapping): string[] {
+    const fields: string[] = [];
+    fields.push(mapping.rows, mapping.cols);
+
+    if (typeof mapping.data === 'string') { fields.push(mapping.data); }
+
+    if (typeof mapping.step === 'string') {
+        fields.push(mapping.step);
+    } else if ('field' in mapping.step) {
+        fields.push((mapping.step as StepMappingOpenCV).field);
     }
-    return variables.every((v, i) => v.name === fmt.descriptor.members[i]);
+
+    if (typeof mapping.channels === 'string') {
+        fields.push(mapping.channels);
+    } else if ('fromFlags' in mapping.channels) {
+        fields.push((mapping.channels as ChannelMappingFromFlags).fromFlags);
+    } else if ('field' in mapping.channels) {
+        fields.push((mapping.channels as ChannelMappingCustom).field);
+    }
+
+    if (typeof mapping.depth === 'string') {
+        fields.push(mapping.depth);
+    } else if ('fromFlags' in mapping.depth) {
+        fields.push((mapping.depth as DepthMappingFromFlags).fromFlags);
+    } else if ('field' in mapping.depth) {
+        fields.push((mapping.depth as DepthMappingFromField | DepthMappingCustom).field);
+    }
+
+    return [...new Set(fields)];
 }
 
 // ---------------------------------------------------------------------------
@@ -168,7 +198,8 @@ function parseAnyPointer(variable: any): Ptr {
     const hex = raw.length < 18
         ? '0x' + raw.slice(2).padStart(16, '0')
         : raw.substring(0, 18);
-    return { addr: parseInt(hex), hex };
+    const bigVal = BigInt(hex);
+    return { addr: Number(bigVal), hex };
 }
 
 function parseIntValue(variable: any): number {
@@ -183,18 +214,32 @@ function parseSizeT(variable: any): number {
 
 function parseOpenCVStep(variable: any): number[] {
     const step_str = String(variable.value);
+
     const bufMatch = step_str.match(/buf=\S+\s*\{([^}]*)\}/);
-    let buf_array: number[] = [];
     if (bufMatch && bufMatch[1]) {
-        buf_array = bufMatch[1].split(',').map(s => parseInt(s.trim())).filter(n => !isNaN(n));
+        const arr = bufMatch[1].split(',').map(s => parseInt(s.trim())).filter(n => !isNaN(n) && n > 0);
+        if (arr.length > 0) { return arr; }
     }
-    const firstMatch = step_str.match(/\{(\d+)\}/);
-    if (firstMatch && firstMatch[1]) {
-        if (buf_array.length === 0 || buf_array[0] !== parseInt(firstMatch[1])) {
-            buf_array.unshift(parseInt(firstMatch[1]));
-        }
+
+    const braceMatch = step_str.match(/\{([^}]+)\}/);
+    if (braceMatch && braceMatch[1]) {
+        const arr = braceMatch[1].split(',').map(s => parseInt(s.trim())).filter(n => !isNaN(n) && n > 0);
+        if (arr.length > 0) { return arr; }
     }
-    return buf_array;
+
+    const bracketMatch = step_str.match(/\[([^\]]+)\]/);
+    if (bracketMatch && bracketMatch[1]) {
+        const arr = bracketMatch[1].split(',').map(s => parseInt(s.trim())).filter(n => !isNaN(n) && n > 0);
+        if (arr.length > 0) { return arr; }
+    }
+
+    const plainNumbers = step_str.match(/\d+/g);
+    if (plainNumbers) {
+        const arr = plainNumbers.map(s => parseInt(s)).filter(n => n > 0);
+        if (arr.length > 0) { return arr; }
+    }
+
+    return [];
 }
 
 function byteSizeToCvDepth(byteSize: number, preferFloat: boolean): number {
@@ -283,19 +328,24 @@ function resolveChannels(mapping: ChannelMapping, variables: any[]): number {
     return 1;
 }
 
-function resolveStep(mapping: StepMapping, variables: any[]): number[] {
+function resolveStep(mapping: StepMapping, variables: any[], cols: number, channels: number, cvDepth: number): number[] {
+    const elemSize1 = [1, 1, 2, 2, 4, 4, 8][cvDepth] ?? 1;
+    const fallback = [cols * channels * elemSize1];
+
     if (typeof mapping === 'string') {
         const m = findMember(variables, mapping);
-        if (!m) { return [0]; }
-        return [parseSizeT(m)];
+        if (!m) { return fallback; }
+        const val = parseSizeT(m);
+        return val > 0 ? [val] : fallback;
     }
     if ('interpret' in mapping) {
         const sm = mapping as StepMappingOpenCV;
         const m = findMember(variables, sm.field);
-        if (!m) { return [0]; }
-        return parseOpenCVStep(m);
+        if (!m) { return fallback; }
+        const result = parseOpenCVStep(m);
+        return result.length > 0 && result[0] > 0 ? result : fallback;
     }
-    return [0];
+    return fallback;
 }
 
 function evalSimpleExpr(expr: string, vars: Record<string, number>): number {
@@ -355,7 +405,7 @@ export function extractImageInfo(
     const channels = resolveChannels(m.channels, variables);
     const cvDepth = resolveDepth(m.depth, variables);
     const dataPtr = parseAnyPointer(dataVar);
-    const step = resolveStep(m.step, variables);
+    const step = resolveStep(m.step, variables, cols, channels, cvDepth);
 
     if (step[0] <= 0) { return null; }
 

--- a/src/mat-utils.ts
+++ b/src/mat-utils.ts
@@ -146,21 +146,29 @@ export async function readMatMemory(
 ): Promise<Uint8Array | null> {
     const count = mat.dataend.addr - mat.datastart.addr;
     if (count <= 0) {
+        console.log(`[ImageWatch] readMatMemory: invalid count ${count} (dataend=${mat.dataend.hex}, datastart=${mat.datastart.hex})`);
         return null;
     }
-    try {
-        const resp = await session.customRequest('readMemory', {
-            memoryReference: mat.datastart.hex,
-            offset: 0,
-            count
-        });
-        if (!resp || !resp.data) {
-            return null;
+
+    const refs = [mat.datastart.hex];
+    const alt = '0x' + mat.datastart.addr.toString(16);
+    if (alt !== mat.datastart.hex) { refs.push(alt); }
+
+    for (const ref of refs) {
+        try {
+            const resp = await session.customRequest('readMemory', {
+                memoryReference: ref,
+                offset: 0,
+                count
+            });
+            if (resp?.data) {
+                return Uint8Array.from(Buffer.from(resp.data, 'base64'));
+            }
+        } catch (err) {
+            console.log(`[ImageWatch] readMemory with ref ${ref} failed:`, err);
         }
-        return Uint8Array.from(Buffer.from(resp.data, 'base64'));
-    } catch {
-        return null;
     }
+    return null;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/mat-utils.ts
+++ b/src/mat-utils.ts
@@ -9,7 +9,7 @@ import {
 // ---------------------------------------------------------------------------
 
 export interface Ptr {
-    addr: number;
+    addr: bigint;
     hex: string;
 }
 
@@ -137,6 +137,20 @@ export function tryParseAsImage(variables: any[]): MatInfo | null {
 }
 
 // ---------------------------------------------------------------------------
+//  Serialize MatInfo for webview postMessage (bigint → number for JSON safety)
+// ---------------------------------------------------------------------------
+
+export function matInfoToMessage(mat: MatInfo): Record<string, unknown> {
+    return {
+        ...mat,
+        data: { hex: mat.data.hex },
+        datastart: { hex: mat.datastart.hex },
+        dataend: { hex: mat.dataend.hex },
+        datalimit: { hex: mat.datalimit.hex },
+    };
+}
+
+// ---------------------------------------------------------------------------
 //  Read pixel memory via DAP
 // ---------------------------------------------------------------------------
 
@@ -144,11 +158,12 @@ export async function readMatMemory(
     session: vscode.DebugSession,
     mat: MatInfo
 ): Promise<Uint8Array | null> {
-    const count = mat.dataend.addr - mat.datastart.addr;
-    if (count <= 0) {
-        console.log(`[ImageWatch] readMatMemory: invalid count ${count} (dataend=${mat.dataend.hex}, datastart=${mat.datastart.hex})`);
+    const countBig = mat.dataend.addr - mat.datastart.addr;
+    if (countBig <= 0n) {
+        console.log(`[ImageWatch] readMatMemory: invalid count ${countBig} (dataend=${mat.dataend.hex}, datastart=${mat.datastart.hex})`);
         return null;
     }
+    const count = Number(countBig);
 
     const refs = [mat.datastart.hex];
     const alt = '0x' + mat.datastart.addr.toString(16);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题描述

修复 #8 - 部分 `cv::Mat` 局部变量无法在 Image Watch 面板中显示，且已显示的图像像素全为 0。

## 根本原因分析

### 问题1：部分 cv::Mat 变量不显示

`matchesMembers` 函数要求调试器返回的变量成员**数量和顺序**与 `BUILTIN_CV_MAT.members` 定义的 12 个成员**完全一致**。但不同编译器（MSVC vs GCC vs Clang）、不同调试器（cppdbg vs cppvsdbg）以及不同 OpenCV 版本报告的成员可能有所不同（例如额外的 vtable 指针、不同的成员排列顺序），导致匹配失败。

### 问题2：像素全为 0

1. **`parseOpenCVStep` 解析不够健壮**：`step` 字段在不同调试器中有不同的字符串表示方式（例如 GDB 的 `{3840}` vs MSVC 的 `buf=0x... {3840, 3, ...}`），当解析失败时返回空数组，使 `step[0]` 为 `undefined`，后续所有依赖 step 的计算变为 `NaN`。
2. **`parseAnyPointer` 精度丢失**：之前的修复将 hex 转为 `BigInt` 但随后立即通过 `Number(bigVal)` 转回 `number`，完全抵消了 BigInt 的精度保护。`Ptr.addr` 仍为 `number` 类型，导致 `dataend - datastart` 在地址超过 `Number.MAX_SAFE_INTEGER` (2^53-1) 时计算出错误的内存大小。
3. **webview 端缺少容错**：`var_from_message` 中对 `step` 为空数组和 `memory` 类型未做防护。

## 修复内容

### format-descriptor.ts
- **`matchesMembers`**：改为基于 mapping 所需字段的子集匹配，只要变量列表包含所有必需字段即可
- **`parseOpenCVStep`**：增加多种格式支持（`buf={...}`、`{...}`、`[...]`、纯数字），逐级尝试匹配
- **`resolveStep`**：解析失败时自动计算 fallback 值 (`cols * channels * elemSize1`)
- **`Ptr.addr` 类型改为 `bigint`**：`parseAnyPointer` 现在直接返回 `BigInt(hex)` 而不是 `Number(BigInt(hex))`，彻底解决 64 位地址精度丢失问题
- **`evalSimpleExpr` 改用 `bigint` 运算**：确保 `dataend - datastart` 等表达式在 64 位地址空间中精确计算

### mat-utils.ts
- **`Ptr.addr` 类型改为 `bigint`**：与 format-descriptor.ts 保持一致
- **`readMatMemory`**：使用 `bigint` 减法计算内存大小，结果转为 `number` 传递给 DAP（内存大小本身永远在安全整数范围内）
- **新增 `matInfoToMessage()`**：序列化 `MatInfo` 时去除 `bigint` 字段（因为 `postMessage` 不支持 BigInt），仅保留 `hex` 字符串
- 尝试多种地址格式调用 `readMemory`，增加错误日志

### image-watch-panel.html (webview)
- **`var_from_message`**：使用 `BigInt(hex)` 计算 data/datastart 偏移量，避免精度丢失；增加 step 为空/0 时的 fallback 处理；确保 memory 为正确的 `Uint8Array` 类型；增加边界检查
- **`array_from_memory`**：修复 TypedArray buffer 对齐问题，避免非对齐内存访问导致数据错误

### debug-tracker.ts / extension.ts
- 发送 `MatInfo` 到 webview 前通过 `matInfoToMessage()` 序列化，避免 `bigint` 序列化错误
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfb22f70-d842-4639-b7d3-1ca79bc2954d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfb22f70-d842-4639-b7d3-1ca79bc2954d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

